### PR TITLE
Issue 47: Use a string replacement function to load a sync function

### DIFF
--- a/src/js/syncModel.js
+++ b/src/js/syncModel.js
@@ -318,7 +318,7 @@ function SyncModel(db) {
     } else {
       seq = ch.seq
     }
-    
+
     ch.doc = doc
     totalChanges++;
     var sync = runSyncFunction(previewChannels, ch.id, ch.doc, seq)
@@ -457,7 +457,7 @@ var syncWrapper = function(newDoc, oldDoc, realUserCtx) {
 
 function compileSyncFunction(syncCode) {
   var codeString = "var syncFun = ("+ syncCode+")",
-    wrappedCode = syncWrapper.replace('"syncCodeStringHere"', codeString),
+    wrappedCode = syncWrapper.replace('"syncCodeStringHere"', function() { return codeString; }),
     evalString = "compiledFunction = ("+ wrappedCode+")",
     compiledFunction;
   eval(evalString);


### PR DESCRIPTION
Ensures that, if the sync function happens to contain a sequence of characters that is a [string replacement pattern](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter), it will be inserted verbatim, rather than being incorrectly interpreted.

Fixes issue #47.